### PR TITLE
use year_frac to calculate YTM

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -2,6 +2,9 @@ on:
   push:
     branches: [main, master]
     tags: ['v*', 'build*']
+  pull_request:
+    types:
+      - opened
 
 name: R-CMD-check
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,9 +1,14 @@
 Package: fcl
 Title: Financial Calculator
 Version: 0.0.11
-Authors@R:
+Authors@R: c(
     person("Xianying", "Tan", , "shrektan@126.com", role = c("aut", "cre"),
-           comment = c("ORCID" = "0000-0002-6072-3521"))
+           comment = c(ORCID = "0000-0002-6072-3521")),
+    person("Raymon", "Mina", , "raymonmina@gmail.com", role = c("ctb"),
+           comment = c("find_root.rs, xirr.rs")),
+    person("Hiroaki", "Yutani", , "yutani.ini@gmail.com", role = c("ctb"),
+           comment = c(ORCID = "0000-0002-3385-7233", "configure, configure.win, tools/configure.R"))
+    )
 Maintainer: Xianying Tan <shrektan@126.com>
 Description: Calculate Bond YTM / Duration, fast time-weighted rate of return, Modified Dietz, etc.
 URL: https://github.com/shrektan/fcl

--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -60,16 +60,6 @@ dependencies = [
  "chrono",
  "extendr-api",
  "extendr-engine",
- "financial",
-]
-
-[[package]]
-name = "financial"
-version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc770cb7bb4d69515cb95598253ba0360b30244e5aea8c65dfb11101a7982f76"
-dependencies = [
- "chrono",
 ]
 
 [[package]]

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -11,5 +11,4 @@ crate-type = [ 'staticlib' ]
 [dependencies]
 extendr-api = '0.2.0'
 extendr-engine = "0.2.0"
-financial = "1.1.3"
 chrono = "0.4.19"

--- a/src/rust/src/assert.rs
+++ b/src/rust/src/assert.rs
@@ -4,6 +4,18 @@ pub trait NearEq {
     fn near_equal(&self, right: &Self) -> bool;
 }
 
+impl NearEq for f64 {
+    fn near_equal(&self, r: &Self) -> bool {
+        let l = &self;
+        // l or r could be NaN or infinite
+        if l.classify() != r.classify() || (*l - *r).abs() > f64::EPSILON.sqrt() {
+            false
+        } else {
+            true
+        }
+    }
+}
+
 impl NearEq for Vec<Option<f64>> {
     fn near_equal(&self, right: &Self) -> bool {
         let left = &self;
@@ -14,8 +26,7 @@ impl NearEq for Vec<Option<f64>> {
         for (i, left_val) in left.iter().enumerate() {
             match (left_val, right[i]) {
                 (Some(l), Some(r)) => {
-                    // l or r could be NaN or infinite
-                    if l.classify() != r.classify() || (l - r).abs() > f64::EPSILON.sqrt() {
+                    if !l.near_equal(&r) {
                         failed = true;
                         break;
                     }
@@ -39,10 +50,7 @@ impl NearEq for Vec<f64> {
         }
         let mut failed = false;
         for (i, left_val) in left.iter().enumerate() {
-            // l or r could be NaN or infinite
-            if left_val.classify() != right[i].classify()
-                || (left_val - right[i]).abs() > f64::EPSILON.sqrt()
-            {
+            if !left_val.near_equal(&right[i]) {
                 failed = true;
                 break;
             }

--- a/src/rust/src/find_root.rs
+++ b/src/rust/src/find_root.rs
@@ -1,0 +1,165 @@
+// copied from https://github.com/raymon1/financial/blob/2ea69baf1fb40906f38e456d8c8b51f08f746083/src/common/find_root.rs
+const PRECISION: f64 = 1e-7;
+const NEWTON_MAX_ITERATION: u32 = 20;
+const BISECTION_MAX_ITERATION: u32 = 2000;
+const INITIAL_GUESS: f64 = 0.;
+
+pub fn find_root<F>(x: Option<f64>, func: F, bounds_search_expansion_factor: f64) -> Option<f64>
+where
+    F: Fn(f64) -> f64,
+{
+    let x = match x {
+        Some(num) => num,
+        None => INITIAL_GUESS,
+    };
+    let f = |x| func(x);
+    let newton_val = newton(x, f);
+    let same_sign = |x: f64, y: f64| {
+        x.is_sign_positive() && y.is_sign_positive() || x.is_sign_negative() && y.is_sign_negative()
+    };
+
+    if newton_val.is_some() && same_sign(newton_val.unwrap(), x) {
+        newton_val
+    } else if let Some(b_pos) =
+        find_bounds(x, Bounds::new_positive(), f, bounds_search_expansion_factor)
+    {
+        bisection(b_pos, f)
+    } else if let Some(b_neg) =
+        find_bounds(x, Bounds::new_negative(), f, bounds_search_expansion_factor)
+    {
+        bisection(b_neg, f)
+    } else {
+        None
+    }
+}
+
+fn newton<F>(x: f64, f: F) -> Option<f64>
+where
+    F: Fn(f64) -> f64,
+{
+    let mut x = x;
+    let df = |x: f64| (f(x + PRECISION) - f(x - PRECISION)) / (2. * PRECISION);
+
+    for _ in 1..NEWTON_MAX_ITERATION {
+        let fx = f(x);
+        let dfx = df(x);
+
+        let new_x = x - fx / dfx;
+
+        if (new_x - x).abs() <= PRECISION || fx.abs() <= PRECISION {
+            return Some(new_x);
+        }
+
+        x = new_x;
+    }
+
+    None
+}
+
+fn bisection<F>(bounds: Bounds, f: F) -> Option<f64>
+where
+    F: Fn(f64) -> f64,
+{
+    let mut a = bounds.lower;
+    let mut b = bounds.upper;
+    for _ in 1..BISECTION_MAX_ITERATION {
+        let fa = f(a);
+        if fa.abs() < PRECISION {
+            return Some(a);
+        } else {
+            let fb = f(b);
+            if fb.abs() < PRECISION {
+                return Some(b);
+            } else {
+                if fa * fb > 0. {
+                    return None;
+                }
+
+                let mid = a + (b - a) / 2.;
+                let fmid = f(mid);
+
+                if fmid.abs() < PRECISION {
+                    return Some(mid);
+                } else {
+                    let fafmid = fa * fmid;
+                    if fafmid < 0. {
+                        b = mid;
+                    } else if fafmid > 0. {
+                        a = mid;
+                    } else {
+                        panic!("it should never get here");
+                    }
+                }
+            }
+        }
+    }
+
+    None
+}
+
+fn find_bounds<F>(x: f64, bounds: Bounds, f: F, expansion_factor: f64) -> Option<Bounds>
+where
+    F: Fn(f64) -> f64,
+{
+    let shift = 0.01;
+    let adjust_to_min = |val| {
+        if val <= bounds.lower {
+            bounds.lower + PRECISION
+        } else {
+            val
+        }
+    };
+    let adjust_to_max = |val| {
+        if val >= bounds.upper {
+            bounds.upper - PRECISION
+        } else {
+            val
+        }
+    };
+
+    let mut low = adjust_to_min(x - shift);
+    let mut upp = adjust_to_max(x + shift);
+    for _ in 1..60 {
+        let lower = adjust_to_min(low);
+        let upper = adjust_to_max(upp);
+        let product = f(lower) * f(upper);
+        if product <= 0. {
+            return Some(Bounds::new_from_range(lower, upper));
+        } else {
+            low = lower + expansion_factor * (lower - upper);
+            upp = upper + expansion_factor * (upper - lower);
+            continue;
+        }
+    }
+
+    None
+}
+
+#[derive(Debug)]
+struct Bounds {
+    lower: f64,
+    upper: f64,
+}
+
+impl Bounds {
+    fn new_positive() -> Bounds {
+        Bounds {
+            lower: 0.,
+            upper: f64::MAX,
+        }
+    }
+
+    fn new_negative() -> Bounds {
+        Bounds {
+            lower: f64::MIN,
+            upper: 0.,
+        }
+    }
+
+    fn new_from_range(lower: f64, upper: f64) -> Bounds {
+        if lower > upper {
+            panic!("lower cannot be greater than upper bounds")
+        }
+        Bounds { lower, upper }
+    }
+}

--- a/src/rust/src/lib.rs
+++ b/src/rust/src/lib.rs
@@ -4,8 +4,10 @@ mod assert;
 mod bond;
 mod check_len;
 mod date_handle;
+mod find_root;
 mod rdate;
 mod rtn;
+mod xirr;
 use rdate::ToRDate;
 use std::collections::BTreeMap;
 

--- a/src/rust/src/xirr.rs
+++ b/src/rust/src/xirr.rs
@@ -1,0 +1,110 @@
+// The code is copied from https://github.com/raymon1/financial with some modifications
+// financial's xirr at current doesn't provide NaiveDate api and use days/365.0 to calculate
+// the year fractions, which is slightly different from what expected normally
+// https://github.com/raymon1/financial/issues/9
+use crate::date_handle;
+use crate::find_root::*;
+use chrono::NaiveDate;
+
+pub struct CheckedCashflowSchedule<'a> {
+    pub values: &'a [f64],
+    pub dates: &'a [NaiveDate],
+}
+
+impl<'a> CheckedCashflowSchedule<'a> {
+    pub fn new(
+        values: &'a [f64],
+        dates: &'a [NaiveDate],
+    ) -> Result<CheckedCashflowSchedule<'a>, &'static str> {
+        if values.len() != dates.len() {
+            return Err("Values and dates length must match");
+        }
+        let d0 = dates.first().unwrap();
+        if dates.iter().any(|d| *d < *d0) {
+            return Err("First date must be the earliest");
+        };
+        Ok(CheckedCashflowSchedule { values, dates })
+    }
+}
+
+pub fn xnpv(rate: f64, values: &[f64], dates: &[NaiveDate]) -> Result<f64, &'static str> {
+    let cf = CheckedCashflowSchedule::new(values, dates);
+    match cf {
+        Err(m) => Err(m),
+        Ok(cf) => Ok(calculate_xnpv(rate, &cf)),
+    }
+}
+
+pub fn calculate_xnpv(rate: f64, cf: &CheckedCashflowSchedule) -> f64 {
+    if cf.values.is_empty() {
+        return 0.;
+    }
+
+    if rate == 0. {
+        return cf.values.iter().sum();
+    }
+
+    let d0 = cf.dates.first().unwrap();
+    cf.values
+        .iter()
+        .zip(cf.dates.iter())
+        .map(|(v, d)| v / f64::powf(1. + rate, date_handle::year_frac(d, &d0)))
+        .sum()
+}
+
+pub fn xirr(values: &[f64], dates: &[NaiveDate], guess: Option<f64>) -> Result<f64, &'static str> {
+    let cf = CheckedCashflowSchedule::new(values, dates);
+
+    match cf {
+        Err(m) => Err(m),
+        Ok(cf) => {
+            let f_xnpv = |x: f64| calculate_xnpv(x, &cf);
+            match find_root(guess, f_xnpv, 1.1) {
+                Some(ans) => Ok(ans),
+                None => Err("could't find irr for the values provided"),
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::{Duration, NaiveDate};
+    use crate::assert::NearEq;
+    #[test]
+    fn xnpv_with_zero_rate() {
+        let cf: [f64; 10000] = [100.; 10000];
+        let somedate: NaiveDate = NaiveDate::from_ymd(2021, 1, 1);
+        let dates0: [NaiveDate; 10000] = [somedate; 10000];
+        let mut dates: [NaiveDate; 10000] = [somedate; 10000];
+
+        let mut i = 0;
+        for d in dates0.iter() {
+            dates[i] = d
+                .checked_add_signed(Duration::weeks(52 * (i as i64)))
+                .unwrap();
+            i = i + 1;
+        }
+
+        assert_eq!(xnpv(0., &cf, &dates).unwrap(), cf.iter().sum());
+    }
+
+    #[test]
+    fn xirr_test() {
+        // non leap year
+        let cf = [-100., 105.];
+        let dates = [
+            NaiveDate::from_ymd(2021, 1, 1),
+            NaiveDate::from_ymd(2022, 1, 1),
+        ];
+        assert_near_eq!(xirr(&cf, &dates, None).unwrap(), 0.05);
+        // leap year
+        let cf = [-100., 105.];
+        let dates = [
+            NaiveDate::from_ymd(2020, 1, 1),
+            NaiveDate::from_ymd(2021, 1, 1),
+        ];
+        assert_near_eq!(xirr(&cf, &dates, None).unwrap(), 0.05);
+    }
+}

--- a/src/rust/src/xirr.rs
+++ b/src/rust/src/xirr.rs
@@ -70,8 +70,8 @@ pub fn xirr(values: &[f64], dates: &[NaiveDate], guess: Option<f64>) -> Result<f
 #[cfg(test)]
 mod tests {
     use super::*;
-    use chrono::{Duration, NaiveDate};
     use crate::assert::NearEq;
+    use chrono::{Duration, NaiveDate};
     #[test]
     fn xnpv_with_zero_rate() {
         let cf: [f64; 10000] = [100.; 10000];

--- a/tests/testthat/test-bond.R
+++ b/tests/testthat/test-bond.R
@@ -3,9 +3,9 @@ test_that("bond works", {
   out <- bond_result(ymd("2021-01-01", "2021-02-01"), ymd("2025-01-01", "2025-02-01"), 100.0, 0.05, 0L, ymd("2022-01-01", "2022-02-01"), 100)
   expect_equal(as.double(out[1,]), as.double(out[2,]))
   expect <- data.frame(
-    YTM = c(0.0454848062096707, 0.0299794780750772),
-    MACD = c(3.00036561713138, 7.23139084505863),
-    MODD = c(2.8721026917994, 7.02455669824076)
+    YTM = c(0.0455272763905981, 0.03),
+    MACD = c(3.0, 7.23028295522156),
+    MODD = c(2.86936559941372, 7.01969218987131)
   )
   out <- bond_result(ymd("2021-01-01", "2021-02-01"), ymd("2025-01-01", "2030-02-01"), 100.0, c(0.05, 0.03), c(0L, 1L), ymd("2022-01-01", "2022-02-01"), 100)
   expect_equal(out, expect)
@@ -38,4 +38,19 @@ test_that("bond works", {
 test_that("bond_result adjusts input to correct length and type", {
   out <- bond_result(211110, 20611110, 100, 0.04830, 2, 211130, c(109.83, 100))
   expect_equal(round(out[, "YTM"], 4), c(0.0436, 0.0489))
+})
+
+test_that("bond_result returns the same for leap and non-leap year", {
+  out <- fcl::bond_result(
+    value_date = c(200101, 210101),
+    mty_date = c(210101, 220101),
+    redem_value = 100,
+    cpn_rate = 0.05,
+    cpn_freq = 1,
+    ref_date = c(200101, 210101),
+    clean_price = 100
+  )
+  expect_equal(out$YTM, c(0.05, 0.05))
+  expect_equal(out$MACD, c(1, 1))
+  expect_equal(out$MODD, c(1 / 1.05, 1 / 1.05))
 })


### PR DESCRIPTION
So that leap and non-leap year input generates same YTM

```r
r$> out <- fcl::bond_result( 
        value_date = c(200101, 210101), 
        mty_date = c(210101, 220101), 
        redem_value = 100, 
        cpn_rate = 0.05, 
        cpn_freq = 1, 
        ref_date = c(200101, 210101), 
        clean_price = 100 
      )                                                           

r$> out                                                           
   YTM MACD     MODD
1 0.05    1 0.952381
2 0.05    1 0.952381
```