### PR TITLE
update to extendr 0.7.0 to address new non-api changes

### DIFF
--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -71,13 +71,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37e366bff8cd32dd8754b0991fb66b279dc48f598c3a18914852a6673deef583"
 dependencies = [
  "quote",
- "syn 2.0.38",
+ "syn",
 ]
 
 [[package]]
 name = "extendr-api"
-version = "0.4.0"
-source = "git+https://github.com/extendr/extendr?rev=refs/pull/627/head#ab1a319e6916995fc10ea3841ecec1ddaf54c9d0"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0701db497d091675e50bb10ba870999742cd1e9a9d94cf3fb52f3ea9a7629c0"
 dependencies = [
  "extendr-macros",
  "libR-sys",
@@ -87,8 +88,9 @@ dependencies = [
 
 [[package]]
 name = "extendr-engine"
-version = "0.4.0"
-source = "git+https://github.com/extendr/extendr?rev=refs/pull/627/head#ab1a319e6916995fc10ea3841ecec1ddaf54c9d0"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ae890e2fffb0973f3c106eabf72a49112022b724a56d34e1511d13b8e9a6039"
 dependencies = [
  "ctor",
  "libR-sys",
@@ -96,12 +98,13 @@ dependencies = [
 
 [[package]]
 name = "extendr-macros"
-version = "0.4.0"
-source = "git+https://github.com/extendr/extendr?rev=refs/pull/627/head#ab1a319e6916995fc10ea3841ecec1ddaf54c9d0"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33d6b806beee182ab3e1105c822df137913b894847a13ec29dfbff9abfb6d1d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn",
 ]
 
 [[package]]
@@ -147,9 +150,9 @@ dependencies = [
 
 [[package]]
 name = "libR-sys"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a34aaa68a201f71eab5df5a67d1326add8aaf029434e939353bcab0534919ff1"
+checksum = "44f2e4b6f402557010b557dd181842168db92da2c0d747bd091bd175941c570d"
 
 [[package]]
 name = "libc"
@@ -204,17 +207,6 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
-
-[[package]]
-name = "syn"
 version = "2.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e96b79aaa137db8f61e26363a0c9b47d8b4ec75da28b7d1d614c2303e232408b"
@@ -251,7 +243,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
@@ -273,7 +265,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -7,8 +7,8 @@ edition = '2021'
 crate-type = ['staticlib']
 
 [dependencies]
-extendr-api = { package = "extendr-api", git = "https://github.com/extendr/extendr", rev = "refs/pull/627/head" }
+extendr-api = { package = "extendr-api", version = "0.7.0" }
 chrono = "0.4.26"
 
 [dev-dependencies]
-extendr-engine = { package = "extendr-engine", git = "https://github.com/extendr/extendr", rev = "refs/pull/627/head" }
+extendr-engine = { package = "extendr-engine", version = "0.7.0" }

--- a/src/rust/src/rdate.rs
+++ b/src/rust/src/rdate.rs
@@ -73,20 +73,20 @@ impl ToRDate for [NaiveDate] {
 
 impl ToRDate for Vec<Option<f64>> {
     fn to_rdate(&self) -> Robj {
-        r!(self.clone()).set_class(&["Date"]).unwrap()
+        r!(self.clone()).set_class(&["Date"]).unwrap().clone()
     }
 }
 
 impl ToRDate for [f64] {
     fn to_rdate(&self) -> Robj {
-        r!(self).set_class(&["Date"]).unwrap()
+        r!(self).set_class(&["Date"]).unwrap().clone()
     }
 }
 
 impl ToRDate for [i32] {
     fn to_rdate(&self) -> Robj {
         let out: Vec<f64> = self.iter().map(|v| *v as f64).collect();
-        r!(out).set_class(&["Date"]).unwrap()
+        r!(out).set_class(&["Date"]).unwrap().clone()
     }
 }
 


### PR DESCRIPTION
This PR addresses new non-api changes in R-devel that are causing warnings on CRAN.

I've bumped your versions of extendr and extendr-engine. Additionally, you will see additional calls to `.clone()` this is because `set_class()` now requires a mutable reference. Cloning the object only increases the reference counter so there is no negative memory impact from this. 
